### PR TITLE
Updated `ProcessesAssets` trait to return `Result<(), Error>`

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,6 +1,7 @@
 //! This module contains things that [ProcessesAssets],
 //! like SCSS compilers, Markdown transpilers, and image
 //! minifiers.
+use ::markdown::message::Message;
 use codas::types::Text;
 
 use crate::asset::media_type::MediaType;
@@ -79,13 +80,27 @@ impl AssetContents {
 /// A thing that processes [Asset]s.
 pub trait ProcessesAssets {
     /// Processes `asset`.
-    fn process(&self, asset: &mut Asset);
+    fn process(&self, asset: &mut Asset) -> Result<(), Error>;
 }
 
 #[derive(Debug)]
 pub enum Error {
     /// An asset contained data that wasn't text.
     NotText,
+    ScssCompilationError,
+    MarkdownCompilationError,
+}
+
+impl From<Box<grass::Error>> for Error {
+    fn from(_error: Box<grass::Error>) -> Self {
+        Error::ScssCompilationError
+    }
+}
+
+impl From<Message> for Error {
+    fn from(_error: Message) -> Self {
+        Error::MarkdownCompilationError
+    }
 }
 
 #[cfg(test)]

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,7 +1,6 @@
 //! This module contains things that [ProcessesAssets],
 //! like SCSS compilers, Markdown transpilers, and image
 //! minifiers.
-use ::markdown::message::Message;
 use codas::types::Text;
 
 use crate::asset::media_type::MediaType;
@@ -69,10 +68,10 @@ impl AssetContents {
     }
 
     /// Returns the contents as mutable text.
-    pub fn try_as_mut_text(&mut self) -> Result<&mut Text, Error> {
+    pub fn try_as_mut_text(&mut self) -> Result<&mut Text, AssetError> {
         match self {
             AssetContents::Text(text) => Ok(text),
-            _ => Err(Error::NotText),
+            _ => Err(AssetError::NotText),
         }
     }
 }
@@ -80,27 +79,16 @@ impl AssetContents {
 /// A thing that processes [Asset]s.
 pub trait ProcessesAssets {
     /// Processes `asset`.
-    fn process(&self, asset: &mut Asset) -> Result<(), Error>;
+    fn process(&self, asset: &mut Asset) -> Result<(), AssetError>;
 }
 
 #[derive(Debug)]
-pub enum Error {
+pub enum AssetError {
     /// An asset contained data that wasn't text.
     NotText,
-    ScssCompilationError,
-    MarkdownCompilationError,
-}
-
-impl From<Box<grass::Error>> for Error {
-    fn from(_error: Box<grass::Error>) -> Self {
-        Error::ScssCompilationError
-    }
-}
-
-impl From<Message> for Error {
-    fn from(_error: Message) -> Self {
-        Error::MarkdownCompilationError
-    }
+    Compilation {
+        message: Text,
+    },
 }
 
 #[cfg(test)]

--- a/src/asset/markdown.rs
+++ b/src/asset/markdown.rs
@@ -1,6 +1,6 @@
 use markdown::mdast::Node;
 
-use crate::asset::{media_type::MediaType, Error, ProcessesAssets};
+use crate::asset::{Error, ProcessesAssets, media_type::MediaType};
 
 pub struct MarkdownProcessor {}
 

--- a/src/asset/markdown.rs
+++ b/src/asset/markdown.rs
@@ -1,11 +1,18 @@
-use markdown::mdast::Node;
+use markdown::{mdast::Node, message::Message};
 
-use crate::asset::{Error, ProcessesAssets, media_type::MediaType};
+use crate::asset::{AssetError, ProcessesAssets, media_type::MediaType};
 
+impl From<Message> for AssetError {
+    fn from(error: Message) -> Self {
+        AssetError::Compilation {
+            message: error.to_string().into(),
+        }
+    }
+}
 pub struct MarkdownProcessor {}
 
 impl ProcessesAssets for MarkdownProcessor {
-    fn process(&self, asset: &mut super::Asset) -> Result<(), Error> {
+    fn process(&self, asset: &mut super::Asset) -> Result<(), AssetError> {
         let text = asset.contents.try_as_mut_text()?;
 
         // Compile markdown into an abstract syntax tree.

--- a/src/asset/markdown.rs
+++ b/src/asset/markdown.rs
@@ -1,15 +1,15 @@
 use markdown::mdast::Node;
 
-use crate::asset::{ProcessesAssets, media_type::MediaType};
+use crate::asset::{media_type::MediaType, Error, ProcessesAssets};
 
 pub struct MarkdownProcessor {}
 
 impl ProcessesAssets for MarkdownProcessor {
-    fn process(&self, asset: &mut super::Asset) {
-        let text = asset.contents.try_as_mut_text().expect("todo");
+    fn process(&self, asset: &mut super::Asset) -> Result<(), Error> {
+        let text = asset.contents.try_as_mut_text()?;
 
         // Compile markdown into an abstract syntax tree.
-        let ast = markdown::to_mdast(text, &markdown::ParseOptions::default()).unwrap();
+        let ast = markdown::to_mdast(text, &markdown::ParseOptions::default())?;
 
         // Compile the AST into HTML.
         let mut compiled_html = String::with_capacity(text.len());
@@ -18,6 +18,7 @@ impl ProcessesAssets for MarkdownProcessor {
         // Update the asset's contents and target extension.
         *text.to_mut() = compiled_html;
         asset.media_type = MediaType::Html;
+        Ok(())
     }
 }
 
@@ -254,7 +255,7 @@ mod tests {
                 .to_vec(),
         );
 
-        MarkdownProcessor {}.process(&mut markdown_asset);
+        let _ = MarkdownProcessor {}.process(&mut markdown_asset);
 
         assert_eq!(
             "<h1 id=\"header-1\">Header 1</h1><p>Body</p><Blockquote><p>Quotation in <strong>bold</strong> and <em>italics</em>.</p></Blockquote>",

--- a/src/asset/scss.rs
+++ b/src/asset/scss.rs
@@ -2,23 +2,25 @@ use std::path::Path;
 
 use grass::{Options, from_path};
 
-use crate::asset::{ProcessesAssets, media_type::MediaType};
+use crate::asset::{Error, ProcessesAssets, media_type::MediaType};
 
 pub struct ScssProcessor {}
 
 impl ProcessesAssets for ScssProcessor {
-    fn process(&self, asset: &mut super::Asset) {
+    fn process(&self, asset: &mut super::Asset) -> Result<(), Error> {
         // Get Path Ref
         let path_text = asset.path().clone();
         let path: &str = path_text.as_ref();
 
         // Compile SCSS file at selected path to CSS
-        let css = from_path(Path::new(path), &Options::default()).unwrap();
+        let css = from_path(Path::new(path), &Options::default())?;
 
         // Update the asset's contents and target extension.
-        let text = asset.contents.try_as_mut_text().expect("todo");
+        let text = asset.contents.try_as_mut_text()?;
         *text.to_mut() = css;
         asset.media_type = MediaType::Css;
+
+        Ok(())
     }
 }
 
@@ -33,7 +35,7 @@ mod tests {
         let mut simple_scss_asset =
             Asset::new("test/simple_example.scss".into(), "".as_bytes().to_vec());
 
-        ScssProcessor {}.process(&mut simple_scss_asset);
+        let _ = ScssProcessor {}.process(&mut simple_scss_asset);
 
         assert_eq!(
             "body {\n  font: 100% Helvetica, sans-serif;\n  color: #333;\n}\n",
@@ -45,7 +47,7 @@ mod tests {
             "".as_bytes().to_vec(),
         );
 
-        ScssProcessor {}.process(&mut simple_nested_scss_asset);
+        let _ = ScssProcessor {}.process(&mut simple_nested_scss_asset);
 
         assert_eq!(
             "nav ul {\n  margin: 0;\n  padding: 0;\n  list-style: none;\n}\nnav li {\n  display: inline-block;\n}\nnav a {\n  display: block;\n  padding: 6px 12px;\n  text-decoration: none;\n}\n",

--- a/src/asset/scss.rs
+++ b/src/asset/scss.rs
@@ -2,12 +2,19 @@ use std::path::Path;
 
 use grass::{Options, from_path};
 
-use crate::asset::{Error, ProcessesAssets, media_type::MediaType};
+use crate::asset::{AssetError, ProcessesAssets, media_type::MediaType};
 
+impl From<Box<grass::Error>> for AssetError {
+    fn from(error: Box<grass::Error>) -> Self {
+        AssetError::Compilation {
+            message: error.to_string().into(),
+        }
+    }
+}
 pub struct ScssProcessor {}
 
 impl ProcessesAssets for ScssProcessor {
-    fn process(&self, asset: &mut super::Asset) -> Result<(), Error> {
+    fn process(&self, asset: &mut super::Asset) -> Result<(), AssetError> {
         // Get Path Ref
         let path_text = asset.path().clone();
         let path: &str = path_text.as_ref();


### PR DESCRIPTION
## What's Here
- Updated `ProcessesAssets` trait to return `Result<(), Error>`
- Introduced `Error` enum variants for SCSS and Markdown compilation errors.
- Modified `MarkdownProcessor` and `ScssProcessor` implementations to handle errors appropriately.
- Updated tests to reflect changes in the process method signature.

<!-- Except for checking the box, do not edit any of the content below here. -->
##  Legal Stuff
- [x] By checking this box, I confirm that I have read and agree to the terms of the below Contributors' License Agreement.

> ### With Caer Contributors' License Agreement, Version 1.0
>
> I give With Caer, LLC permission to license my contributions on any terms they like. I am giving them this license in order to make it possible for them to accept my contributions into their project.
>
> ***As far as the law allows, my contributions come as is, without any warranty or condition, and I will not be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***