### PR TITLE
feat: TemplateProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This file contains a chronological list of all major changes made to this crate.
 - Add tokenizer/lexer for ~{..} style templates.
 - Partially implement template processor
 - This is what we in the industry call a mess
+- Added JS bundling processor using brk_rolldown (#10)
+
+### 🐛 Fixes
+
+- Compiler errors
+- Template tests
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 This file contains a chronological list of all major changes made to this crate.
 
+## Unreleased Changes
+
+### 🚀 Features
+
+- Add tokenizer/lexer for ~{..} style templates.
+- Partially implement template processor
+- This is what we in the industry call a mess
+
+### Other Changes
+
+- Extract template tokenizers into separate module
+- Modify tokenizer to use S-expressions for function calls
+- Add utility for taking identifier tokens
+- Rename TemplateExpression::Variable to ::Identifier
+
 ## [0.1.0] - 2025-09-28
 
 ### 🚀 Features

--- a/src/proc/template.rs
+++ b/src/proc/template.rs
@@ -93,7 +93,8 @@ impl TemplateProcessor {
 
                         // If statement: ~{ if condition } ... ~{ end }
                         "if" => {
-                            let identifier = self.context.get(&args[0].try_as_text()?).cloned();
+                            let identifier =
+                                self.context.get(&args[0].try_as_identifier()?).cloned();
 
                             // A variable reference is "truthy" if it exists and is not "false" or "0".
                             let truthy =
@@ -215,7 +216,7 @@ mod tests {
     fn processes_if_template() {
         let mut asset = Asset::new(
             "test.html".into(),
-            r#"~{ (if is_empty) }This is empty!~{ (end) }"#.trim().as_bytes().to_vec(),
+            r#"~{ if is_empty }This is empty!~{ end }"#.trim().as_bytes().to_vec(),
         );
         asset.set_media_type(MediaType::Html);
 

--- a/src/proc/template/tokenizer.rs
+++ b/src/proc/template/tokenizer.rs
@@ -11,7 +11,7 @@ pub enum Token {
     OpenTemplate(Result<TemplateExpression, String>),
 }
 
-/// Tokenizer for an indiviudal template expression.
+/// Tokenizer for an individual template expression.
 #[derive(Logos, Debug, PartialEq, Eq, Clone)]
 #[logos(skip r"[ \t\n\f]+")]
 enum TemplateToken {
@@ -80,10 +80,12 @@ fn parse_template_expression(lexer: &mut Lexer<Token>) -> Result<TemplateExpress
                     let slice = template_lexer.slice();
                     // Remove the surrounding quotes and unescape.
                     let unescaped = slice[1..slice.len() - 1]
+                        .replace(r#"\\\\"#, r#"\\"#) // handle escaped backslash first (for double escaping)
+                        .replace(r#"\\"#, r#"\ "#) // handle single escaped backslash
                         .replace(r#"\""#, r#"""#)
                         .replace(r#"\n"#, "\n")
                         .replace(r#"\t"#, "\t")
-                        .replace(r#"\\"#, r#"\"#);
+                        .replace(r#"\ "#, r#"\\"#); // restore single backslash
                     args.push(TemplateExpression::String(unescaped.into()));
                 }
                 TemplateToken::CloseTemplate => {


### PR DESCRIPTION
<!-- Describe your pull request here. -->
## What's Here
- Added a `TemplateProcessor` which compiles text templates like `~{# var}` based on a context map.

<!-- Except for checking the box, do not edit any of the content below here. -->
##  Legal Stuff
- [x] By checking this box, I confirm that I have read and agree to the terms of the below Contributors' License Agreement.

> ### With Caer Contributors' License Agreement, Version 1.0
>
> I give With Caer, LLC permission to license my contributions on any terms they like. I am giving them this license in order to make it possible for them to accept my contributions into their project.
>
> ***As far as the law allows, my contributions come as is, without any warranty or condition, and I will not be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***